### PR TITLE
Allow list_n_or_more to validate empty lists.

### DIFF
--- a/krankshaft/valid.py
+++ b/krankshaft/valid.py
@@ -569,9 +569,9 @@ def list_n_or_more(validator, n):
     Wrap a validator that also validates the returned list has one or more
     members.
     '''
-    if n < 1:
+    if n < 0:
         raise KrankshaftError(
-            'list_n_or_more only accepts values >= 1, not %s' % n
+            'list_n_or_more only accepts values >= 0, not %s' % n
         )
 
     def list_n_or_more_validator(data, expect):

--- a/tests/krankshaft/test_valid.py
+++ b/tests/krankshaft/test_valid.py
@@ -499,7 +499,7 @@ class ValidatorsTest(BaseExpecterTest):
         self.expect_raises(valid.list_n_or_more(valid.int, 1), ['a',2], errors={0: ["invalid literal for int() with base 10: 'a'"]})
 
     def test_list_n_or_more_invalid_n(self):
-        self.assertRaises(valid.KrankshaftError, valid.list_n_or_more, valid.int, 0)
+        self.assertRaises(valid.KrankshaftError, valid.list_n_or_more, valid.int, -1)
 
     def test_slug(self):
         self.expect(valid.slug, 'HELLO WORLD', 'hello-world')


### PR DESCRIPTION
This allows it to work with array fields. Note that you still need to register the validator to the field with api.expector.register().