### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ will be built in directly.
 .. image:: https://coveralls.io/repos/dlamotte/krankshaft/badge.png
    :target: https://coveralls.io/r/dlamotte/krankshaft
 
-.. image:: https://pypip.in/v/krankshaft/badge.png
+.. image:: https://img.shields.io/pypi/v/krankshaft.svg
    :target: https://pypi.python.org/pypi/krankshaft
 
 .. image:: https://d2weczhvl823v0.cloudfront.net/dlamotte/krankshaft/trend.png


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20krankshaft))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `krankshaft`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.